### PR TITLE
Update to veideman-commons version 0.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <docker.tag>${project.version}</docker.tag>
 
-        <veidemann.commons.version>0.4.0</veidemann.commons.version>
+        <veidemann.commons.version>0.4.1</veidemann.commons.version>
         <veidemann.rethinkdbadapter.version>0.4.0</veidemann.rethinkdbadapter.version>
 
         <log4j.version>2.12.1</log4j.version>

--- a/src/main/java/no/nb/nna/veidemann/controller/ControllerService.java
+++ b/src/main/java/no/nb/nna/veidemann/controller/ControllerService.java
@@ -155,10 +155,7 @@ public class ControllerService extends ControllerGrpc.ControllerImplBase {
     @Override
     public void getRolesForActiveUser(Empty request, StreamObserver<RoleList> responseObserver) {
         try {
-            Collection<Role> roles = RolesContextKey.roles()
-                    .stream()
-                    .map(r -> Role.valueOf(r.name()))
-                    .collect(Collectors.toSet());
+            Collection<Role> roles = RolesContextKey.roles();
             if (roles == null) {
                 responseObserver.onNext(RoleList.newBuilder().build());
             } else {


### PR DESCRIPTION
Bug in veidemann-commons 0.4.0  triggered an IllegalArgumentException causing call's to getRolesForActiveUser to fail when controller was configured to skip authentication.