### PR TITLE
Update allowed roles

### DIFF
--- a/src/main/java/no/nb/nna/veidemann/controller/ControllerService.java
+++ b/src/main/java/no/nb/nna/veidemann/controller/ControllerService.java
@@ -77,7 +77,7 @@ public class ControllerService extends ControllerGrpc.ControllerImplBase {
     }
 
     @Override
-    @AllowedRoles({Role.CURATOR, Role.ADMIN})
+    @AllowedRoles({Role.CURATOR, Role.ADMIN, Role.OPERATOR})
     public void runCrawl(RunCrawlRequest request, StreamObserver<RunCrawlReply> responseObserver) {
         try {
             ConfigRef jobRequest = ConfigRef.newBuilder()
@@ -134,7 +134,7 @@ public class ControllerService extends ControllerGrpc.ControllerImplBase {
     }
 
     @Override
-    @AllowedRoles({Role.OPERATOR, Role.ADMIN})
+    @AllowedRoles({Role.OPERATOR, Role.ADMIN, Role.CURATOR})
     public void abortCrawlExecution(ExecutionId request, StreamObserver<CrawlExecutionStatus> responseObserver) {
         try {
             CrawlExecutionStatus status = executionsAdapter.setCrawlExecutionStateAborted(
@@ -150,7 +150,7 @@ public class ControllerService extends ControllerGrpc.ControllerImplBase {
     }
 
     @Override
-    @AllowedRoles({Role.OPERATOR, Role.ADMIN})
+    @AllowedRoles({Role.OPERATOR, Role.ADMIN, Role.CURATOR})
     public void abortJobExecution(ExecutionId request, StreamObserver<JobExecutionStatus> responseObserver) {
         try {
             JobExecutionStatus status = executionsAdapter.setJobExecutionStateAborted(request.getId());
@@ -224,7 +224,7 @@ public class ControllerService extends ControllerGrpc.ControllerImplBase {
     }
 
     @Override
-    @AllowedRoles({Role.OPERATOR, Role.ADMIN})
+    @AllowedRoles({Role.OPERATOR, Role.ADMIN, Role.CONSULTANT, Role.CURATOR, Role.ANY_USER})
     public void status(Empty request, StreamObserver<CrawlerStatus> responseObserver) {
         try {
             boolean desiredPausedState = executionsAdapter.getDesiredPausedState();

--- a/src/main/java/no/nb/nna/veidemann/controller/ReportService.java
+++ b/src/main/java/no/nb/nna/veidemann/controller/ReportService.java
@@ -66,7 +66,7 @@ public class ReportService extends ReportGrpc.ReportImplBase {
     }
 
     @Override
-    @AllowedRoles({Role.CURATOR, Role.OPERATOR, Role.ADMIN})
+    @AllowedRoles({Role.CURATOR, Role.OPERATOR, Role.ADMIN, Role.CONSULTANT})
     public void listCrawlLogs(CrawlLogListRequest request, StreamObserver<CrawlLog> responseObserver) {
         new Thread(() -> {
             try (ChangeFeed<CrawlLog> c = executionsAdapter.listCrawlLogs(request);) {
@@ -134,7 +134,7 @@ public class ReportService extends ReportGrpc.ReportImplBase {
     }
 
     @Override
-    @AllowedRoles({Role.OPERATOR, Role.ADMIN})
+    @AllowedRoles({Role.OPERATOR, Role.ADMIN, Role.CURATOR, Role.CONSULTANT})
     public void executeDbQuery(ExecuteDbQueryRequest request, StreamObserver<ExecuteDbQueryReply> respObserver) {
         try {
             ReqlAst qry = QueryEngine.getInstance().parseQuery(request.getQuery());


### PR DESCRIPTION
Update allowed roles to match rules in dashboard.

- Crawler status should be readable for all logged in users (Admin, Operator, Curator, Consultant, Any_User)
- Run / Abort Crawl (job and crawlexecution) allowed for users Admin, Operator and Curator
- executeDbQuery  allowed for all users with access to pagelog report (Admin, Operator, Curator, Consultant)
- listCrawlLogs  allowed for all users with access to crawllog report (Admin, Operator, Curator, Consultant)