### PR TITLE
Upgrade rethinkdbadapter version to 0.5.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
         <veidemann.api.version>1.0.0-beta20</veidemann.api.version>
         <veidemann.commons.version>0.4.9</veidemann.commons.version>
-        <veidemann.rethinkdbadapter.version>0.5.5</veidemann.rethinkdbadapter.version>
+        <veidemann.rethinkdbadapter.version>0.5.7</veidemann.rethinkdbadapter.version>
 
         <com.github.netflix.concurrency-limits.version>0.3.7</com.github.netflix.concurrency-limits.version>
         <log4j.version>2.13.3</log4j.version>


### PR DESCRIPTION
Listrequest for jobexecutions no longer aggregate execution states.