### PR TITLE
Allow querying on fields not explicitly present in database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,9 @@
         <docker.tag>${project.version}</docker.tag>
 
         <veidemann.api.version>1.0.0-beta23</veidemann.api.version>
-        <veidemann.commons.version>0.5.0</veidemann.commons.version>
-        <veidemann.rethinkdbadapter.version>0.7.0</veidemann.rethinkdbadapter.version>
+        <veidemann.commons.version>v0.6.0</veidemann.commons.version>
+        <veidemann.rethinkdbadapter.version>v0.9.0</veidemann.rethinkdbadapter.version>
+        <io.opentracing.version>0.33.0</io.opentracing.version>
 
         <com.github.netflix.concurrency-limits.version>0.3.7</com.github.netflix.concurrency-limits.version>
         <log4j.version>2.13.3</log4j.version>
@@ -85,6 +86,33 @@
             <groupId>com.github.netflix.concurrency-limits</groupId>
             <artifactId>concurrency-limits-grpc</artifactId>
             <version>${com.github.netflix.concurrency-limits.version}</version>
+        </dependency>
+
+        <!-- Tracing dependencies -->
+        <dependency>
+            <groupId>io.jaegertracing</groupId>
+            <artifactId>jaeger-client</artifactId>
+            <version>1.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <version>${io.opentracing.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+            <version>${io.opentracing.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-noop</artifactId>
+            <version>${io.opentracing.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-grpc</artifactId>
+            <version>0.2.3</version>
         </dependency>
 
         <!-- Configuration framework -->
@@ -169,11 +197,11 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M5</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M5</version>
             </plugin>
 
             <!-- Make version number available for application -->
@@ -192,7 +220,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>3.0.0</version>
                 <configuration>
                     <to>
                         <image>docker.io/norsknettarkiv/${project.artifactId}</image>

--- a/src/main/java/no/nb/nna/veidemann/controller/Controller.java
+++ b/src/main/java/no/nb/nna/veidemann/controller/Controller.java
@@ -20,10 +20,12 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigBeanFactory;
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigFactory;
+import io.jaegertracing.Configuration;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
 import no.nb.nna.veidemann.commons.auth.UserRoleMapper;
 import no.nb.nna.veidemann.commons.db.DbException;
 import no.nb.nna.veidemann.commons.db.DbService;
-import no.nb.nna.veidemann.commons.opentracing.TracerFactory;
 import no.nb.nna.veidemann.controller.scheduler.CrawlJobScheduler;
 import no.nb.nna.veidemann.controller.settings.Settings;
 import org.slf4j.Logger;
@@ -45,7 +47,8 @@ public class Controller {
         config.checkValid(ConfigFactory.defaultReference());
         SETTINGS = ConfigBeanFactory.create(config, Settings.class);
 
-        TracerFactory.init("Controller");
+        Tracer tracer = Configuration.fromEnv().getTracer();
+        GlobalTracer.registerIfAbsent(tracer);
     }
 
     public Controller() {

--- a/src/main/java/no/nb/nna/veidemann/controller/ControllerApiServer.java
+++ b/src/main/java/no/nb/nna/veidemann/controller/ControllerApiServer.java
@@ -21,7 +21,8 @@ import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.ServerServiceDefinition;
-import io.opentracing.contrib.ServerTracingInterceptor;
+import io.opentracing.contrib.grpc.TracingServerInterceptor;
+import io.opentracing.contrib.grpc.TracingServerInterceptor.ServerRequestAttribute;
 import io.opentracing.util.GlobalTracer;
 import no.nb.nna.veidemann.commons.auth.ApiKeyAuAuServerInterceptor;
 import no.nb.nna.veidemann.commons.auth.ApiKeyRoleMapper;
@@ -97,9 +98,10 @@ public class ControllerApiServer implements AutoCloseable {
     }
 
     public ControllerApiServer start() {
-        ServerTracingInterceptor tracingInterceptor = new ServerTracingInterceptor.Builder(GlobalTracer.get())
-                .withTracedAttributes(ServerTracingInterceptor.ServerRequestAttribute.CALL_ATTRIBUTES,
-                        ServerTracingInterceptor.ServerRequestAttribute.METHOD_TYPE)
+        TracingServerInterceptor tracingInterceptor = TracingServerInterceptor
+                .newBuilder()
+                .withTracer(GlobalTracer.get())
+                .withTracedAttributes(ServerRequestAttribute.CALL_ATTRIBUTES, ServerRequestAttribute.METHOD_TYPE)
                 .build();
 
         List<ServerInterceptor> interceptors = new ArrayList<>();

--- a/src/main/java/no/nb/nna/veidemann/controller/FrontierClient.java
+++ b/src/main/java/no/nb/nna/veidemann/controller/FrontierClient.java
@@ -26,7 +26,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.opentracing.contrib.ClientTracingInterceptor;
+import io.opentracing.contrib.grpc.TracingClientInterceptor;
 import io.opentracing.util.GlobalTracer;
 import no.nb.nna.veidemann.api.config.v1.ConfigObject;
 import no.nb.nna.veidemann.api.frontier.v1.CountResponse;
@@ -69,7 +69,8 @@ public class FrontierClient implements AutoCloseable {
 
     public FrontierClient(ManagedChannelBuilder<?> channelBuilder, String supportedSeedType) {
         LOG.info("Setting up Frontier client");
-        ClientInterceptor tracingInterceptor = new ClientTracingInterceptor.Builder(GlobalTracer.get()).build();
+
+        ClientInterceptor tracingInterceptor = TracingClientInterceptor.newBuilder().withTracer(GlobalTracer.get()).build();
         ClientInterceptor pressureLimitInterceptor = new ConcurrencyLimitClientInterceptor(
                 new GrpcClientLimiterBuilder()
                         .partitionByMethod()

--- a/src/main/java/no/nb/nna/veidemann/controller/JobExecutionUtil.java
+++ b/src/main/java/no/nb/nna/veidemann/controller/JobExecutionUtil.java
@@ -59,7 +59,7 @@ public class JobExecutionUtil {
     private final static ExecutorService exe = Executors.newFixedThreadPool(16);
     private final static ExecutorService submitSeedExecutor =
             new ThreadPoolExecutor(4, 16, 10L, TimeUnit.SECONDS,
-                    new LinkedBlockingQueue(5000), new CallerRunsPolicy());
+                    new LinkedBlockingQueue<>(5000), new CallerRunsPolicy());
 
     private JobExecutionUtil() {
     }

--- a/src/main/java/no/nb/nna/veidemann/controller/ScopeServiceClient.java
+++ b/src/main/java/no/nb/nna/veidemann/controller/ScopeServiceClient.java
@@ -18,9 +18,10 @@ package no.nb.nna.veidemann.controller;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.opentracing.contrib.ClientTracingInterceptor;
+import io.opentracing.contrib.grpc.TracingClientInterceptor;
 import io.opentracing.util.GlobalTracer;
 import no.nb.nna.veidemann.api.uricanonicalizer.v1.CanonicalizeRequest;
 import no.nb.nna.veidemann.api.uricanonicalizer.v1.CanonicalizeResponse;
@@ -56,7 +57,8 @@ public class ScopeServiceClient implements AutoCloseable {
 
     public ScopeServiceClient(ManagedChannelBuilder<?> channelBuilder) {
         LOG.info("Setting up scope service client");
-        ClientTracingInterceptor tracingInterceptor = new ClientTracingInterceptor.Builder(GlobalTracer.get()).build();
+        ClientInterceptor tracingInterceptor = TracingClientInterceptor.newBuilder()
+                .withTracer(GlobalTracer.get()).build();
         channel = channelBuilder.intercept(tracingInterceptor).build();
         blockingStub = UriCanonicalizerServiceGrpc.newBlockingStub(channel);
         asyncStub = UriCanonicalizerServiceGrpc.newStub(channel);

--- a/src/test/java/no/nb/nna/veidemann/controller/ArrayChangeFeed.java
+++ b/src/test/java/no/nb/nna/veidemann/controller/ArrayChangeFeed.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 public class ArrayChangeFeed<T> implements ChangeFeed<T> {
     final T[] values;
 
+    @SafeVarargs
     public ArrayChangeFeed(T... values) {
         this.values = values;
     }


### PR DESCRIPTION
veidemann-rethinkdbadapter has been updated to allow querying fields not explicitly present in database.

This resulted in needing to also update to newest OpenTracing API.