### PR TITLE
Use distroless as base image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,9 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>3.0.0</version>
                 <configuration>
+                    <from>
+                        <image>gcr.io/distroless/java:11</image>
+                    </from>
                     <to>
                         <image>ghcr.io/nlnwa/${project.artifactId}</image>
                     </to>

--- a/src/main/java/no/nb/nna/veidemann/controller/scheduler/ScheduledCrawlJob.java
+++ b/src/main/java/no/nb/nna/veidemann/controller/scheduler/ScheduledCrawlJob.java
@@ -52,7 +52,7 @@ public class ScheduledCrawlJob extends Task {
             JobExecutionStatus jobExecutionStatus = JobExecutionUtil.getRunningJobExecutionStatusForJob(job);
             if (jobExecutionStatus == null) {
                 LOG.debug("Job '{}' starting", job.getMeta().getName());
-                JobExecutionUtil.submitSeeds(job, jobExecutionStatus, calculateTimeout(job), false, Collections.EMPTY_LIST);
+                JobExecutionUtil.submitSeeds(job, null, calculateTimeout(job), false, Collections.emptyList());
             } else {
                 LOG.info("The job '{}' is already running. Job execution: '{}'", job.getMeta().getName(), jobExecutionStatus.getId());
             }


### PR DESCRIPTION
Must explicitly configure this in Github Actions context to get jib to choose distroless as base image.

This PR also contain a fix to get rid of a unchecked cast warning.